### PR TITLE
Adding support for custom repository branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,13 @@ The resulting `apm` binary will be available in `./build/apm`.
 Starts tracking a plugin repository.
 
 ```shell
-apm add-repository --alias foo --url https://github.com/joshua-kim/foobar
+apm add-repository --alias foo --url https://github.com/joshua-kim/foobar --branch master
 ```
 
 #### Parameters:
 - `--alias`: The alias of the VM to install.
 - `--url`: The alias of the VM to install.
+- `--branch`: The branch name to track.
  
 ### install-vm
 Installs a virtual machine by its alias. 

--- a/apm/apm.go
+++ b/apm/apm.go
@@ -106,7 +106,7 @@ func New(config Config) (*APM, error) {
 	if ok, err := a.sourcesList.Has(coreKey); err != nil {
 		return nil, err
 	} else if !ok {
-		err := a.AddRepository(constant.CoreAlias, constant.CoreURL)
+		err := a.AddRepository(constant.CoreAlias, constant.CoreURL, constant.CoreBranch)
 		if err != nil {
 			return nil, err
 		}
@@ -328,12 +328,13 @@ func (a *APM) upgradeVM(name string) error {
 	))
 }
 
-func (a *APM) AddRepository(alias string, url string) error {
+func (a *APM) AddRepository(alias string, url string, branch string) error {
 	wf := workflow.NewAddRepository(
 		workflow.AddRepositoryConfig{
 			SourcesList: a.sourcesList,
 			Alias:       alias,
 			URL:         url,
+			Branch:      plumbing.NewBranchReferenceName(branch),
 		},
 	)
 
@@ -389,14 +390,14 @@ func (a *APM) ListRepositories() error {
 	itr := a.sourcesList.Iterator()
 
 	w := tabwriter.NewWriter(os.Stdout, 1, 1, 1, ' ', 0)
-	fmt.Fprintln(w, "alias\turl")
+	fmt.Fprintln(w, "alias\turl\tbranch")
 	for itr.Next() {
 		metadata, err := itr.Value()
 		if err != nil {
 			return err
 		}
 
-		fmt.Fprintf(w, "%s\t%s\n", metadata.Alias, metadata.URL)
+		fmt.Fprintf(w, "%s\t%s\t%s\n", metadata.Alias, metadata.URL, metadata.Branch)
 	}
 	w.Flush()
 	return nil

--- a/cmd/add_repository.go
+++ b/cmd/add_repository.go
@@ -11,6 +11,8 @@ import (
 func addRepository(fs afero.Fs) *cobra.Command {
 	url := ""
 	alias := ""
+	branch := ""
+
 	command := &cobra.Command{
 		Use:   "add-repository",
 		Short: "Adds a custom repository to the list of tracked repositories",
@@ -28,13 +30,19 @@ func addRepository(fs afero.Fs) *cobra.Command {
 		panic(err)
 	}
 
+	command.PersistentFlags().StringVar(&branch, "branch", "", "branch name to track")
+	err = command.MarkPersistentFlagRequired("branch")
+	if err != nil {
+		panic(err)
+	}
+
 	command.RunE = func(_ *cobra.Command, _ []string) error {
 		apm, err := initAPM(fs)
 		if err != nil {
 			return err
 		}
 
-		return apm.AddRepository(alias, url)
+		return apm.AddRepository(alias, url, branch)
 	}
 
 	return command

--- a/constant/constants.go
+++ b/constant/constants.go
@@ -4,7 +4,8 @@
 package constant
 
 const (
-	AppName   = "apm"
-	CoreAlias = "ava-labs/avalanche-plugins-core"
-	CoreURL   = "https://github.com/ava-labs/avalanche-plugins-core.git"
+	AppName    = "apm"
+	CoreAlias  = "ava-labs/avalanche-plugins-core"
+	CoreURL    = "https://github.com/ava-labs/avalanche-plugins-core.git"
+	CoreBranch = "master"
 )

--- a/storage/source_info.go
+++ b/storage/source_info.go
@@ -12,9 +12,10 @@ import (
 
 // SourceInfo represents a repository, its source, and the last synced commit.
 type SourceInfo struct {
-	Alias  string        `yaml:"alias"`
-	URL    string        `yaml:"url"`
-	Commit plumbing.Hash `yaml:"commit"`
+	Alias  string                 `yaml:"alias"`
+	URL    string                 `yaml:"url"`
+	Commit plumbing.Hash          `yaml:"commit"`
+	Branch plumbing.ReferenceName `yaml:"branch"`
 }
 
 // RepoList is a list of repositories that support a single plugin alias.

--- a/workflow/add_repository.go
+++ b/workflow/add_repository.go
@@ -18,17 +18,20 @@ func NewAddRepository(config AddRepositoryConfig) *AddRepository {
 		sourcesList: config.SourcesList,
 		alias:       config.Alias,
 		url:         config.URL,
+		branch:      config.Branch,
 	}
 }
 
 type AddRepositoryConfig struct {
 	SourcesList storage.Storage[storage.SourceInfo]
 	Alias, URL  string
+	Branch      plumbing.ReferenceName
 }
 
 type AddRepository struct {
 	sourcesList storage.Storage[storage.SourceInfo]
 	alias, url  string
+	branch      plumbing.ReferenceName
 }
 
 func (a AddRepository) Execute() error {
@@ -43,6 +46,7 @@ func (a AddRepository) Execute() error {
 	unsynced := storage.SourceInfo{
 		Alias:  a.alias,
 		URL:    a.url,
+		Branch: a.branch,
 		Commit: plumbing.ZeroHash, // hasn't been synced yet
 	}
 	return a.sourcesList.Put(aliasBytes, unsynced)

--- a/workflow/add_repository_test.go
+++ b/workflow/add_repository_test.go
@@ -53,6 +53,7 @@ func TestAddRepositoryExecute(t *testing.T) {
 						storage.SourceInfo{
 							Alias:  "alias",
 							URL:    "url",
+							Branch: "master",
 							Commit: plumbing.ZeroHash,
 						},
 					).
@@ -72,6 +73,7 @@ func TestAddRepositoryExecute(t *testing.T) {
 						storage.SourceInfo{
 							Alias:  "alias",
 							URL:    "url",
+							Branch: "master",
 							Commit: plumbing.ZeroHash,
 						},
 					).
@@ -101,6 +103,7 @@ func TestAddRepositoryExecute(t *testing.T) {
 					SourcesList: sourcesList,
 					Alias:       "alias",
 					URL:         "url",
+					Branch:      "master",
 				},
 			)
 

--- a/workflow/update.go
+++ b/workflow/update.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 
 	"github.com/ava-labs/avalanchego/database"
-	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/spf13/afero"
 
@@ -21,7 +20,6 @@ var (
 	_ Workflow = &Update{}
 
 	// TODO configurable branches
-	master = plumbing.NewBranchReferenceName("master")
 )
 
 type UpdateConfig struct {
@@ -88,7 +86,7 @@ func (u Update) Execute() error {
 		}
 		previousCommit := sourceInfo.Commit
 		repositoryPath := filepath.Join(u.repositoriesPath, organization, repo)
-		latestCommit, err := u.gitFactory.GetRepository(sourceInfo.URL, repositoryPath, master, &u.auth)
+		latestCommit, err := u.gitFactory.GetRepository(sourceInfo.URL, repositoryPath, sourceInfo.Branch, &u.auth)
 		if err != nil {
 			return err
 		}

--- a/workflow/update_repository.go
+++ b/workflow/update_repository.go
@@ -88,6 +88,7 @@ func (u *UpdateRepository) Execute() error {
 		Alias:  u.repositoryMetadata.Alias,
 		URL:    u.repositoryMetadata.URL,
 		Commit: u.latestCommit,
+		Branch: u.repositoryMetadata.Branch,
 	}
 	if err := u.sourcesList.Put(u.aliasBytes, updatedCheckpoint); err != nil {
 		return err

--- a/workflow/update_repository_test.go
+++ b/workflow/update_repository_test.go
@@ -31,6 +31,8 @@ func TestUpdateRepositoryExecute(t *testing.T) {
 		spacesSubnet = "spaces"
 	)
 	var (
+		branch = plumbing.NewBranchReferenceName("branch")
+
 		subnetsPath = filepath.Join(repositoryPath, "subnets")
 		vmsPath     = filepath.Join(repositoryPath, "vms")
 
@@ -40,6 +42,7 @@ func TestUpdateRepositoryExecute(t *testing.T) {
 		sourceInfo     = storage.SourceInfo{
 			Alias:  alias,
 			URL:    url,
+			Branch: branch,
 			Commit: previousCommit,
 		}
 	)
@@ -155,6 +158,7 @@ func TestUpdateRepositoryExecute(t *testing.T) {
 				mocks.sourcesList.EXPECT().Put([]byte(alias), storage.SourceInfo{
 					Alias:  alias,
 					URL:    url,
+					Branch: branch,
 					Commit: latestCommit,
 				})
 			},
@@ -190,6 +194,7 @@ func TestUpdateRepositoryExecute(t *testing.T) {
 				mocks.sourcesList.EXPECT().Put([]byte(alias), storage.SourceInfo{
 					Alias:  alias,
 					URL:    url,
+					Branch: branch,
 					Commit: latestCommit,
 				})
 			},

--- a/workflow/update_test.go
+++ b/workflow/update_test.go
@@ -44,9 +44,12 @@ func TestUpdateExecute(t *testing.T) {
 			Password: "password",
 		}
 
+		branch = plumbing.NewBranchReferenceName("branch")
+
 		sourceInfo = storage.SourceInfo{
 			Alias:  alias,
 			URL:    url,
+			Branch: branch,
 			Commit: previousCommit,
 		}
 
@@ -113,7 +116,7 @@ func TestUpdateExecute(t *testing.T) {
 					return *storage.NewIterator[storage.SourceInfo](itr)
 				})
 
-				mocks.gitFactory.EXPECT().GetRepository(url, repoInstallPath, master, &mocks.auth).Return(plumbing.ZeroHash, errWrong)
+				mocks.gitFactory.EXPECT().GetRepository(url, repoInstallPath, branch, &mocks.auth).Return(plumbing.ZeroHash, errWrong)
 			},
 			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
 				return assert.Equal(t, errWrong, err)
@@ -148,7 +151,7 @@ func TestUpdateExecute(t *testing.T) {
 					Fs:             fs,
 				})
 
-				mocks.gitFactory.EXPECT().GetRepository(url, repoInstallPath, master, &mocks.auth).Return(latestCommit, nil)
+				mocks.gitFactory.EXPECT().GetRepository(url, repoInstallPath, branch, &mocks.auth).Return(latestCommit, nil)
 				mocks.repoFactory.EXPECT().GetRepository([]byte(alias)).Return(repository)
 				mocks.executor.EXPECT().Execute(wf).Return(errWrong)
 			},
@@ -173,7 +176,7 @@ func TestUpdateExecute(t *testing.T) {
 					return *storage.NewIterator[storage.SourceInfo](itr)
 				})
 
-				mocks.gitFactory.EXPECT().GetRepository(url, repoInstallPath, master, &mocks.auth).Return(previousCommit, nil)
+				mocks.gitFactory.EXPECT().GetRepository(url, repoInstallPath, branch, &mocks.auth).Return(previousCommit, nil)
 			},
 			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
 				return assert.NoError(t, err)
@@ -209,7 +212,7 @@ func TestUpdateExecute(t *testing.T) {
 					Fs:             fs,
 				})
 
-				mocks.gitFactory.EXPECT().GetRepository(url, repoInstallPath, master, &mocks.auth).Return(latestCommit, nil)
+				mocks.gitFactory.EXPECT().GetRepository(url, repoInstallPath, branch, &mocks.auth).Return(latestCommit, nil)
 				mocks.repoFactory.EXPECT().GetRepository([]byte(alias)).Return(repository)
 				mocks.executor.EXPECT().Execute(wf).Return(nil)
 			},


### PR DESCRIPTION
If you're using the current unstable/latest branch of the APM, this PR will require you to wipe your database (`rm -rf ~/.apm`) since it modifies how some data is persisted.