### PR TITLE
Appease linter

### DIFF
--- a/workflow/update.go
+++ b/workflow/update.go
@@ -16,11 +16,7 @@ import (
 	"github.com/ava-labs/apm/util"
 )
 
-var (
-	_ Workflow = &Update{}
-
-	// TODO configurable branches
-)
+var _ Workflow = &Update{}
 
 type UpdateConfig struct {
 	Executor         Executor


### PR DESCRIPTION
Linter failing for `gofumpt` reasons. [failed run](https://github.com/ava-labs/apm/runs/7290900197?check_suite_focus=true). 

Script to auto-gofumpt the whole project:
```
gofumpt -l -w .
```