### PR TITLE
feat(types)!: Using new definition schema

### DIFF
--- a/apm/apm.go
+++ b/apm/apm.go
@@ -222,9 +222,10 @@ func (a *APM) joinSubnet(fullName string) error {
 	}
 
 	subnet := definition.Definition
+	subnetID, _ := subnet.GetID(constant.DefaultNetwork)
 
 	// TODO prompt user, add force flag
-	fmt.Printf("Installing virtual machines for subnet %s.\n", subnet.GetID())
+	fmt.Printf("Installing virtual machines for subnet %s.\n", subnetID)
 	for _, vm := range subnet.VMs {
 		if err := a.Install(strings.Join([]string{alias, vm}, constant.QualifiedNameDelimiter)); err != nil {
 			return err
@@ -238,8 +239,8 @@ func (a *APM) joinSubnet(fullName string) error {
 		return err
 	}
 
-	fmt.Printf("Whitelisting subnet %s...\n", subnet.GetID())
-	if err := a.adminClient.WhitelistSubnet(subnet.GetID()); errors.Is(err, syscall.ECONNREFUSED) {
+	fmt.Printf("Whitelisting subnet %s...\n", subnetID)
+	if err := a.adminClient.WhitelistSubnet(subnetID); errors.Is(err, syscall.ECONNREFUSED) {
 		fmt.Printf("Node at %s was offline. You'll need to whitelist the subnet upon node restart.\n", a.adminAPIEndpoint)
 	} else if err != nil {
 		return err

--- a/constant/constants.go
+++ b/constant/constants.go
@@ -10,4 +10,5 @@ const (
 	CoreBranch             = "master"
 	QualifiedNameDelimiter = ":"
 	AliasDelimiter         = "/"
+	DefaultNetwork         = "testnet"
 )

--- a/state/repository.go
+++ b/state/repository.go
@@ -18,9 +18,6 @@ var (
 	vmDir     = "vms"
 	subnetDir = "subnets"
 
-	vmKey     = "vm"
-	subnetKey = "subnet"
-
 	extension = "yaml"
 )
 
@@ -37,18 +34,18 @@ type DiskRepository struct {
 }
 
 func (d DiskRepository) GetVM(name string) (Definition[types.VM], error) {
-	return get[types.VM](d, vmDir, name, vmKey)
+	return get[types.VM](d, vmDir, name)
 }
 
 func (d DiskRepository) GetSubnet(name string) (Definition[types.Subnet], error) {
-	return get[types.Subnet](d, subnetDir, name, subnetKey)
+	return get[types.Subnet](d, subnetDir, name)
 }
 
 func (d DiskRepository) GetPath() string {
 	return d.Path
 }
 
-func get[T types.Definition](d DiskRepository, dir string, file string, key string) (Definition[T], error) {
+func get[T types.Definition](d DiskRepository, dir string, file string) (Definition[T], error) {
 	relativePathWithExtension := filepath.Join(dir, fmt.Sprintf("%s.%s", file, extension))
 	absolutePathWithExtension := filepath.Join(d.Path, relativePathWithExtension)
 	bytes, err := os.ReadFile(absolutePathWithExtension)
@@ -56,12 +53,11 @@ func get[T types.Definition](d DiskRepository, dir string, file string, key stri
 		return Definition[T]{}, err
 	}
 
-	data := make(map[string]T)
-	if err := yaml.Unmarshal(bytes, data); err != nil {
+	var definition T
+	if err := yaml.Unmarshal(bytes, &definition); err != nil {
 		return Definition[T]{}, err
 	}
 
-	definition := data[key]
 	commit, err := d.Git.GetLastModified(d.Path, relativePathWithExtension)
 	if err != nil {
 		return Definition[T]{}, err

--- a/types/definition.go
+++ b/types/definition.go
@@ -4,7 +4,6 @@
 package types
 
 type Definition interface {
-	GetID() string
 	GetAlias() string
 	GetHomepage() string
 	GetDescription() string

--- a/types/subnet.go
+++ b/types/subnet.go
@@ -6,17 +6,18 @@ package types
 var _ Definition = &Subnet{}
 
 type Subnet struct {
-	ID          string   `yaml:"id"`
-	Alias       string   `yaml:"alias"`
-	Homepage    string   `yaml:"homepage"`
-	Description string   `yaml:"description"`
-	Maintainers []string `yaml:"maintainers"`
-	VMs         []string `yaml:"vms"`
+	ID          map[string]string `yaml:"id"`
+	Alias       string            `yaml:"alias"`
+	Homepage    string            `yaml:"homepage"`
+	Description string            `yaml:"description"`
+	Maintainers []string          `yaml:"maintainers"`
+	VMs         []string          `yaml:"vms"`
 	// Config      subnets.SubnetConfig `yaml:"config,omitempty"`
 }
 
-func (s Subnet) GetID() string {
-	return s.ID
+func (s Subnet) GetID(network string) (string, bool) {
+	id, ok := s.ID[network]
+	return id, ok
 }
 
 func (s Subnet) GetAlias() string {

--- a/workflow/uninstall_test.go
+++ b/workflow/uninstall_test.go
@@ -17,19 +17,21 @@ import (
 func TestUninstallExecute(t *testing.T) {
 	name := "organization/repository:vm"
 
+	vm := types.VM{
+		ID:            "id",
+		Alias:         "vm",
+		Homepage:      "homepage",
+		Description:   "description",
+		Maintainers:   []string{"joshua", "kim"},
+		InstallScript: "./installScript",
+		BinaryPath:    "./build/binaryPath",
+		URL:           "url",
+		SHA256:        "sha256",
+	}
+
 	definition := state.Definition[types.VM]{
-		Definition: types.VM{
-			ID:            "id",
-			Alias:         "vm",
-			Homepage:      "homepage",
-			Description:   "description",
-			Maintainers:   []string{"joshua", "kim"},
-			InstallScript: "./installScript",
-			BinaryPath:    "./build/binaryPath",
-			URL:           "url",
-			SHA256:        "sha256",
-		},
-		Commit: "commit",
+		Definition: vm,
+		Commit:     "commit",
 	}
 
 	type mocks struct {
@@ -52,7 +54,7 @@ func TestUninstallExecute(t *testing.T) {
 			name: "success",
 			setup: func(mocks mocks) {
 				mocks.stateFile.InstallationRegistry[name] = &state.InstallInfo{
-					ID:     definition.Definition.GetID(),
+					ID:     vm.GetID(),
 					Commit: definition.Commit,
 				}
 			},


### PR DESCRIPTION
BREAKING CHANGE: This alters the definition yaml schema

This changes:
1. Subnets can now have a map of networks -> ids for subnets that exist in multiple networks
2. vm/subnet headers are now gone

Part of https://github.com/ava-labs/apm/issues/1